### PR TITLE
Ticket #8704: Range change timer

### DIFF
--- a/group3hallprobeSup/group3hallprobe_probe.db
+++ b/group3hallprobeSup/group3hallprobe_probe.db
@@ -45,7 +45,30 @@ record(ai, "$(P)$(SENSORID):FIELD:_RAW") {
 	field(FLNK, "$(P)$(SENSORID):FIELD")
 }
 
+record (ai, "$(P)$(SENSORID):_LAST_CHANGE_TIME") {
+    field(DESC, "Time the range was last changed")
+    field(DTYP, "Soft Timestamp"
+    field(INPA, "$(P)CS:IOC:G3HALLPR_01:DEVIOS:GTIM_TIME"
+}
+
+#
+# Compare time now with time since last range change.
+# If less than preset period, then output 1 to _RECENT_RANGE_CHANGE
+#
+record (calcout, "$(P)$(SENSORID):_RANGE_CHANGE_MSS") {
+    field(DESC, "Set the MSS of RANGE:SP")
+    field(INPA, "$(P)CS:IOC:G3HALLPR_01:DEVIOS:GTIM_TIME CP"
+    field(INPB, "$(P)$(SENSORID):_LAST_CHANGE_TIME CP"
+    field(INPC, "$(P)$(SENSORID):STATEMACHINE:STATE_CHANGE_DELAY"
+    field(calc, "ABS(A-B) < C"
+    field(out, "$(P)$(SENSORID):_RECENT_RANGE_CHANGE PP")
+}
+
+#
+# This is written to by _RANGE_CHANGE_MSS record
+#
 record(bo, "$(P)$(SENSORID):_RECENT_RANGE_CHANGE") {
+    field(DESC, "One if < period since last change ")
     field(ZSV, "NO_ALARM")
     field(OSV, "INVALID")
 }
@@ -93,7 +116,11 @@ record(mbbo, "$(P)$(SENSORID):RANGE:SP") {
 	field(ONST, "0.6 Tesla")
 	field(TWST, "1.2 Tesla")
 	field(THST, "3.0 Tesla")
-	
+
+    # Need to prevent another range change within a set period since the last one
+    # to prevent instability.
+	field (FLNK, "$(P)$(SENSORID):_LAST_CHANGE_TIME PP")
+
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:$(SENSORID):RANGE:SP")
     field(SDIS, "$(P)DISABLE")

--- a/group3hallprobeSup/group3hallprobe_probe.db
+++ b/group3hallprobeSup/group3hallprobe_probe.db
@@ -14,6 +14,8 @@ record(bo, "$(P)$(SENSORID):INIT") {
 	field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:$(SENSORID):INIT")
     field(SDIS, "$(P)DISABLE")
+
+    field(FLNK, "$(P)$(SENSORID):_LAST_CHANGE_TIME")
 }
 
 record(longout, "$(P)$(SENSORID):TRIGGER") {
@@ -47,8 +49,8 @@ record(ai, "$(P)$(SENSORID):FIELD:_RAW") {
 
 record (ai, "$(P)$(SENSORID):_LAST_CHANGE_TIME") {
     field(DESC, "Time the range was last changed")
-    field(DTYP, "Soft Timestamp"
-    field(INPA, "$(P)CS:IOC:G3HALLPR_01:DEVIOS:GTIM_TIME"
+    field(DTYP, "Soft Timestamp")
+    field(INPA, "$(PVPREFIX)CS:IOC:$(IOCNAME):DEVIOS:GTIM_TIME")
 }
 
 #
@@ -57,11 +59,11 @@ record (ai, "$(P)$(SENSORID):_LAST_CHANGE_TIME") {
 #
 record (calcout, "$(P)$(SENSORID):_RANGE_CHANGE_MSS") {
     field(DESC, "Set the MSS of RANGE:SP")
-    field(INPA, "$(P)CS:IOC:G3HALLPR_01:DEVIOS:GTIM_TIME CP"
-    field(INPB, "$(P)$(SENSORID):_LAST_CHANGE_TIME CP"
-    field(INPC, "$(P)$(SENSORID):STATEMACHINE:STATE_CHANGE_DELAY"
-    field(calc, "ABS(A-B) < C"
-    field(out, "$(P)$(SENSORID):_RECENT_RANGE_CHANGE PP")
+    field(INPA, "$(PVPREFIX)CS:IOC:$(IOCNAME):DEVIOS:GTIM_TIME CP")
+    field(INPB, "$(P)$(SENSORID):_LAST_CHANGE_TIME CP")
+    field(INPC, "$(P)$(SENSORID):STATEMACHINE:STATE_CHANGE_DELAY CP")
+    field(CALC, "ABS(A-B) < C")
+    field(OUT, "$(P)$(SENSORID):_RECENT_RANGE_CHANGE PP")
 }
 
 #

--- a/group3hallprobeSup/group3hallprobe_probe.db
+++ b/group3hallprobeSup/group3hallprobe_probe.db
@@ -45,10 +45,16 @@ record(ai, "$(P)$(SENSORID):FIELD:_RAW") {
 	field(FLNK, "$(P)$(SENSORID):FIELD")
 }
 
+record(bo, "$(P)$(SENSORID):_RECENT_RANGE_CHANGE") {
+    field(ZSV, "NO_ALARM")
+    field(OSV, "INVALID")
+}
+
 record(calc, "$(P)$(SENSORID):FIELD") {
     field(DESC, "Field")
     field(INPA, "$(P)$(SENSORID):FIELD:_RAW MSS")
 	field(B, "$(SCALE)")
+	field(INPC, "$(P)$(SENSORID):_RECENT_RANGE_CHANGE CP MSS")
 	field(CALC, "A*B")
 	field(EGU, "G")
 	field(PREC, "3")


### PR DESCRIPTION
Ticket #8704
Inhibit field readings for two seconds after a range change. This is to prevent spikes in measurements when there has been a recent range change.
